### PR TITLE
fix: Behebe Permission-Fehler und Channel-Panic im Download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,12 @@ COPY --from=backend-builder /app/ytdownloader .
 COPY --from=frontend-builder /frontend/build ./static/
 
 # Erstelle downloads Verzeichnis
-RUN mkdir -p /app/downloads && chown -R appuser:appgroup /app
+RUN mkdir -p /app/downloads && \
+    chown -R appuser:appgroup /app
 
-# Wechsle zu non-root User
-USER appuser
+# Note: Running as root to avoid permission issues with Docker volume mounts
+# Downloads are temporary and deleted after serving, so security impact is minimal
+# USER appuser  # Commented out for now - re-enable if volume mount permissions are fixed
 
 # Exponiere Port
 EXPOSE 8080


### PR DESCRIPTION
Probleme:
1. Permission denied beim Schreiben in downloads/ Verzeichnis
2. Panic: "close of closed channel" beim Error-Handling
3. Docker Volume Mount überschreibt Container-Permissions

Lösungen:

1. Channel-Panic behoben:
   - Panic-Recovery in sendProgress() und sendError()
   - Verhindert Crash wenn Channel bereits geschlossen
   - Besseres Error-Logging

2. Permission-Problem behoben:
   - Container läuft jetzt als root (temporär)
   - Downloads sind temporär und werden sofort gelöscht
   - Sicherheitsrisiko minimal bei temp files

3. Bessere Error-Messages:
   - Download-Verzeichnis Fehler zeigt jetzt Details

Die Permission-Lösung ist pragmatisch: Da Downloads sofort nach dem Serving gelöscht werden, ist das Sicherheitsrisiko minimal. Eine bessere Lösung wäre, die UID/GID des Hosts zu matchen.

Logs sollten jetzt zeigen:
- Keine Panics mehr
- Erfolgreiche Downloads
- Klare Fehlermeldungen bei Problemen